### PR TITLE
Add .vex to extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
                     "vex"
                 ],
                 "extensions": [
-                    ".vfl"
+                    ".vfl",
+                    ".vex"
                 ],
                 "configuration": "./language-configuration.json"
             }


### PR DESCRIPTION
using .vex in the latest version of VSCode did not work until adding this change.